### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ else
 	S = function(s) return s end
 end
 
-if minetest.get_modpath("unified_inventory") or not minetest.setting_getbool("creative_mode") then
+if minetest.get_modpath("unified_inventory") or not minetest.settings:get_bool("creative_mode") then
 	ilights.expect_infinite_stacks = false
 else
 	ilights.expect_infinite_stacks = true


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267