### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,13 @@ ilights = {}
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 else
 	S = function(s) return s end
 end

--- a/init.lua
+++ b/init.lua
@@ -6,7 +6,7 @@ ilights = {}
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S
-if minetest.get_modpath("intllib") then
+if minetest.global_exists("intllib") then
 	S = intllib.Getter()
 else
 	S = function(s) return s end


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using
old function *intllib.Getter*.
- Call *minetest.global_exists* in place of *minetest.get_modpath* for *intllib* check (better practice in my opinion).